### PR TITLE
Ahora también se utiliza node geocoder para calcular el coste de envío por si falla la api

### DIFF
--- a/restapi/controllers/orderController.ts
+++ b/restapi/controllers/orderController.ts
@@ -40,6 +40,7 @@ export const addOrder = async (req: Request, res: Response): Promise<Response> =
       _productos: productosCarrito,
       _fecha: fecha
     });
+    console.log(direccion);
     newOrder._precio = (parseFloat(newOrder._precio) + await shippo.calculaCostes(newOrder._direccion)).toString()
     newOrder.save();
     return res.status(200).json(newOrder);

--- a/restapi/package-lock.json
+++ b/restapi/package-lock.json
@@ -20,6 +20,7 @@
         "express-validator": "6.14.0",
         "jsonwebtoken": "^8.5.1",
         "mongoose": "^6.2.4",
+        "node-geocoder": "^4.0.0",
         "prom-client": "^14.0.1",
         "shippo": "^1.7.1"
       },
@@ -1585,6 +1586,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
       "version": "1.19.2",
@@ -4316,6 +4322,18 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-geocoder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-geocoder/-/node-geocoder-4.0.0.tgz",
+      "integrity": "sha512-/lD7tkVzP2B4rbcyKiNUr/tRgzAw3zowDy8LXOzUxeLnRIMxjQ5a04RhkbJq3RgeKVD0MDpe+FCDX/rJoAColQ==",
+      "dependencies": {
+        "bluebird": "^3.5.2",
+        "node-fetch": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/node-int64": {
@@ -7055,6 +7073,11 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
@@ -9150,6 +9173,15 @@
             "webidl-conversions": "^3.0.0"
           }
         }
+      }
+    },
+    "node-geocoder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-geocoder/-/node-geocoder-4.0.0.tgz",
+      "integrity": "sha512-/lD7tkVzP2B4rbcyKiNUr/tRgzAw3zowDy8LXOzUxeLnRIMxjQ5a04RhkbJq3RgeKVD0MDpe+FCDX/rJoAColQ==",
+      "requires": {
+        "bluebird": "^3.5.2",
+        "node-fetch": "^2.6.0"
       }
     },
     "node-int64": {

--- a/restapi/package.json
+++ b/restapi/package.json
@@ -20,6 +20,7 @@
     "express-validator": "6.14.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.2.4",
+    "node-geocoder": "^4.0.0",
     "prom-client": "^14.0.1",
     "shippo": "^1.7.1"
   },

--- a/restapi/shippo/shippo.ts
+++ b/restapi/shippo/shippo.ts
@@ -1,6 +1,8 @@
 var shippo = require('shippo')('shippo_test_6c13bfbe7eb02c86ba55b13f1cce5badbb465cf6');
+const NodeGeocoder = require('node-geocoder');
+const geocoder = NodeGeocoder({ provider: 'openstreetmap' })
 
-export async function calculaCostes(addressTo: object) {
+export async function calculaCostes(addressTo: Map<string, string>) {
     var addressFrom = {
         "name": "Sergio Castillo",
         "street1": "95 Wall St",
@@ -18,6 +20,8 @@ export async function calculaCostes(addressTo: object) {
         "weight": "2",
         "mass_unit": "lb"
     };
+    var string = addressTo.get('street1') + " " + addressTo.get('city') + " " + addressTo.get('zip') + " " + addressTo.get('country');
+    const res = await geocoder.geocode(string);
 
     return shippo.shipment.create({
         "address_from": addressFrom,
@@ -27,14 +31,59 @@ export async function calculaCostes(addressTo: object) {
     }).then((shipment: any, err: any) => {
         if (err != null) {
             console.log("Ha ocurrido un error al calcular los gastos de envio: " + err);
-            return 5;//Si hay algun error, se aplica una tarifa estandar de 5€
+            return getCosteEnvio(res[0].latitude, res[0].longitude);
         }
         if (shipment?.rates === undefined) {
             console.log("Ha ocurrido un error al calcular los gastos de envio: Se aplicará una tarifa estandar");
-            return 5;//Si hay algun error, se aplica una tarifa estandar de 5€
+            return getCosteEnvio(res[0].latitude, res[0].longitude);
         }
         var costes = shipment?.rates[0].amount
-        console.log("Costes de envio = ", costes);
+        console.log("Costes de envio mediante shippo = ", costes);
         return costes;
     });
+}
+
+function getCosteEnvio(lat1: number, lon1: number) {
+    var direccionBase = {
+        latitude: 40.7047056,
+        longitude: -74.00756981131559,
+        formattedAddress: '95 Wall Street, 95, Wall Street, Manhattan Community Board 1, New York County, New York, 10005, United States',
+        country: 'United States',
+        city: 'New York',
+        state: 'New York',
+        zipcode: '10005',
+        streetName: 'Wall Street',
+        streetNumber: '95',
+        countryCode: 'US',
+        neighbourhood: 'Manhattan Community Board 1',
+        provider: 'openstreetmap'
+    }
+
+    // https://www.geeksforgeeks.org/program-distance-two-points-earth/#:~:text=For%20this%20divide%20the%20values,is%20the%20radius%20of%20Earth.
+    // The math module contains a function
+    // named toRadians which converts from
+    // degrees to radians.
+    lon1 = lon1 * Math.PI / 180;
+    direccionBase.longitude = direccionBase.longitude * Math.PI / 180;
+    lat1 = lat1 * Math.PI / 180;
+    direccionBase.latitude = direccionBase.latitude * Math.PI / 180;
+
+    // Haversine formula
+    let dlon = direccionBase.longitude - lon1;
+    let dlat = direccionBase.latitude - lat1;
+    let a = Math.pow(Math.sin(dlat / 2), 2)
+        + Math.cos(lat1) * Math.cos(direccionBase.latitude)
+        * Math.pow(Math.sin(dlon / 2), 2);
+
+    let c = 2 * Math.asin(Math.sqrt(a));
+
+    // Radius of earth in kilometers. Use 3956
+    // for miles
+    let r = 6371;
+
+    // calculate the result
+    var kilometers = c * r;
+    var result = kilometers * 0.2; // 0,20€/km precio medio de kilometraje en España
+    console.log("Calculado el envío mediante la distancia: " + result + " €");
+    return result;
 }


### PR DESCRIPTION
Se utiliza node geocoder para calcular las coordenadas de la dirección del usuario. Se utiliza una función que calcula los kilómetros entre ambas coordenadas y se multiplica por un precio fijado.